### PR TITLE
update package to 1.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [py<38]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
@@ -19,6 +19,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
+    - wheel
     - pip
     - setuptools_scm >=8.0.0
   run:
@@ -38,9 +39,11 @@ about:
   home: https://github.com/ionelmc/python-lazy-object-proxy
   license: BSD-2-Clause
   license_file: LICENSE
+  license_family: BSD
   summary: A fast and thorough lazy object proxy
+  description: |
+    A fast and thorough lazy object proxy
   doc_url: https://python-lazy-object-proxy.readthedocs.org
-  doc_source_url: https://github.com/ionelmc/python-lazy-object-proxy/blob/master/docs/index.rst
   dev_url: https://github.com/ionelmc/python-lazy-object-proxy
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.0" %}
+{% set version = "1.10.0" %}
 
 package:
   name: lazy-object-proxy
@@ -6,10 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/l/lazy-object-proxy/lazy-object-proxy-{{ version }}.tar.gz
-  sha256: 489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726
+  sha256: 78247b6d45f43a52ef35c25b5581459e85117225408a4128a3daf8bf9648ac69
 
 build:
   number: 0
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -19,7 +20,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools_scm >=3.3.1
+    - setuptools_scm >=8.0.0
   run:
     - python
 
@@ -27,6 +28,11 @@ test:
   imports:
     - lazy_object_proxy
     - lazy_object_proxy.cext  # [python_impl != "pypy"]
+  requires:
+    - pip
+  commands:
+    - pip check
+
 
 about:
   home: https://github.com/ionelmc/python-lazy-object-proxy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - python
     - wheel
     - pip
+    - setuptools
     - setuptools_scm >=8.0.0
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - wheel
     - pip
-    - setuptools
+    - setuptools >=64
     - setuptools_scm >=8.0.0
   run:
     - python


### PR DESCRIPTION
lazy-object-proxy 1.10 

**Destination channel:** defaults

### Links

- [PKG-4434](https://anaconda.atlassian.net/browse/PKG-4434) 
- [Upstream repository](https://github.com/ionelmc/python-lazy-object-proxy)
- [Upstream changelog/diff](https://github.com/ionelmc/python-lazy-object-proxy/releases/tag/v1.10.0)
- Relevant dependency PRs:
  - moto

### Explanation of changes:
- update version and update testing


[PKG-4434]: https://anaconda.atlassian.net/browse/PKG-4434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ