### PR TITLE
lazy-object-proxy 1.12.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,44 @@
-{% set version = "1.10.0" %}
+{% set name = "lazy-object-proxy" %}
+{% set version = "1.12.0" %}
 
 package:
-  name: lazy-object-proxy
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/l/lazy-object-proxy/lazy-object-proxy-{{ version }}.tar.gz
-  sha256: 78247b6d45f43a52ef35c25b5581459e85117225408a4128a3daf8bf9648ac69
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  sha256: 1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61
 
 build:
-  number: 1
-  skip: true  # [py<38]
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
-    - python
-    - wheel
     - pip
-    - setuptools >=64
-    - setuptools_scm >=8.0.0
+    - python
+    - setuptools >=80
+    - setuptools_scm >=8
   run:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - lazy_object_proxy
-    - lazy_object_proxy.cext  # [python_impl != "pypy"]
-  requires:
-    - pip
+    - lazy_object_proxy.cext
   commands:
     - pip check
-
+    - pytest -v tests
+  requires:
+    - pip
+    - pytest
+    - pytest-benchmark
 
 about:
   home: https://github.com/ionelmc/python-lazy-object-proxy


### PR DESCRIPTION
lazy-object-proxy 1.12.0 

**Destination channel:** Defaults

### Links

- [PKG-10315]
- dev_url:        https://github.com/ionelmc/python-lazy-object-proxy/tree/v1.12.0
- conda_forge:    https://github.com/conda-forge/lazy-object-proxy-feedstock
- pypi:           https://pypi.org/project/lazy-object-proxy/1.12.0
- pypi inspector: https://inspector.pypi.io/project/lazy-object-proxy/1.12.0

### Explanation of changes:

- new version number


[PKG-10315]: https://anaconda.atlassian.net/browse/PKG-10315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ